### PR TITLE
issue #170: Automatic Deployment of Docker Image to AWS.

### DIFF
--- a/Dockerrun.aws.json.template
+++ b/Dockerrun.aws.json.template
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "schweizerischebundesbahnen/conference-buddy:<TAG>",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "9000"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # Conference-Buddy
+
 Conference-Buddy, your buddy app for conferences!
+
+### Test Status
 
 [![Build Status](https://travis-ci.org/SchweizerischeBundesbahnen/conference-buddy.svg?branch=feature%2FSTZE%2Fmake_npm_test_success)](https://travis-ci.org/SchweizerischeBundesbahnen/conference-buddy)
 
+### Deployment Status
+
+[![Circle CI](https://circleci.com/gh/SchweizerischeBundesbahnen/conference-buddy.svg?style=svg)](https://circleci.com/gh/SchweizerischeBundesbahnen/conference-buddy)
+
+
 ### Installation instructions
+
 ```
 git clone https://github.com/SchweizerischeBundesbahnen/conference-buddy.git
 cd conference-buddy
@@ -11,16 +20,19 @@ npm install
 ```
 
 ### Run Conference-Buddy
+
 ```
 npm start
 ```
 
 ### Running unit tests
+
 ```
 npm test
 ```
 
 ### Running E2E tests
+
 ```
 npm run protractor
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+# circle.yml
+machine:
+  python:
+    version: 2.7.3
+  services:
+    - docker
+
+dependencies:
+  pre:
+    - pip install awscli
+    - docker build -t schweizerischebundesbahnen/conference-buddy:$CIRCLE_SHA1 .
+    - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+    - docker push schweizerischebundesbahnen/conference-buddy:$CIRCLE_SHA1
+
+deployment:
+  elasticbeanstalk:
+    branch: develop
+    commands:
+    - ./deploy.sh $CIRCLE_SHA1

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+SHA1=$1
+
+# Create new Elastic Beanstalk version
+EB_BUCKET=eu-central-1-conference-buddy
+DOCKERRUN_FILE=$SHA1-Dockerrun.aws.json
+sed "s/<TAG>/$SHA1/" < Dockerrun.aws.json.template > $DOCKERRUN_FILE
+aws s3 cp $DOCKERRUN_FILE s3://$EB_BUCKET/$DOCKERRUN_FILE --region eu-central-1
+aws elasticbeanstalk create-application-version --application-name conference-buddy \
+  --version-label $SHA1 --source-bundle S3Bucket=$EB_BUCKET,S3Key=$DOCKERRUN_FILE
+
+# Update Elastic Beanstalk environment to new version
+aws elasticbeanstalk update-environment --environment-name conferencebuddy-cd \
+    --version-label $SHA1


### PR DESCRIPTION
* Docker Image wird nun für jeden gepushten Branch gebaut.
* Docker Image des Develops wird bei Pushs/gemergten PullRequests auf AWS[1] deployed via CircleCI.

[1]: http://conferencebuddy-cd.elasticbeanstalk.com/
[2]: https://circleci.com/gh/SchweizerischeBundesbahnen/conference-buddy/