### PR TITLE
enables definition of h2 db location as a sys property

### DIFF
--- a/server/conferencebuddy-business-impl/src/main/resources/email-config-context.xml
+++ b/server/conferencebuddy-business-impl/src/main/resources/email-config-context.xml
@@ -10,7 +10,7 @@
                 <value>classpath:emailConfiguration.properties</value>
             </list>
         </property>
-        <!--allows overriding values in property file by system properties-->
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
         <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
     </bean>
 

--- a/server/conferencebuddy-persistence/src/main/resources/h2.properties
+++ b/server/conferencebuddy-persistence/src/main/resources/h2.properties
@@ -1,0 +1,1 @@
+h2.db.location=~/conf-buddy

--- a/server/conferencebuddy-persistence/src/main/resources/persistence-context.xml
+++ b/server/conferencebuddy-persistence/src/main/resources/persistence-context.xml
@@ -11,6 +11,15 @@
 	<jpa:repositories base-package="ch.sbb.conferencebuddy.persistence" entity-manager-factory-ref="estaEntityManagerFactory"/>
 
 
+    <bean id="persistProps" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <list>
+                <value>classpath:h2.properties</value>
+            </list>
+        </property>
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
+  </bean>
 
     <bean class="ch.sbb.esta.core.persistence.emf.EstaPersistenceUnitPostProcessor">
         <!-- Definiert die Packages der Entity-Klassen -->
@@ -24,7 +33,7 @@
 	<!-- local H2 in-memory database -->
     <!-- used for local development, education, etc. -->
     <bean id="dataSource"  class="ch.sbb.esta.util.persistence.h2.LiquibaseInitializingH2XADataSource">
-        <property name="url" value="jdbc:h2:~/confbuddy;DB_CLOSE_DELAY=-1;MODE=Oracle;" />
+        <property name="url" value="jdbc:h2:${h2.db.location};DB_CLOSE_DELAY=-1;MODE=Oracle;" />
         <property name="username" value="sa" />
         <property name="password" value="" />
     </bean>


### PR DESCRIPTION
Nach diesem PR kann die H2-DB als System Property angegeben werden. Damit ist es möglich, die DB auf das persistente EBS-Volume zu speichern. (bspw unter mount /storage)